### PR TITLE
Conda environment

### DIFF
--- a/docs/source/Installation.rst
+++ b/docs/source/Installation.rst
@@ -45,7 +45,7 @@ How to run the notebooks
 If you want to run the example notebooks in this documentation, you will need a
 few extra dependencies that you can install via:::
 
-    conda env create -f docs/environment.yml
+    conda env create -f environment.yml
     conda activate xinvert
 
 

--- a/environment.yml
+++ b/environment.yml
@@ -13,3 +13,4 @@ dependencies:
   - proplot
   - cartopy
   - pooch
+  - ipykernel


### PR DESCRIPTION
I added ipykernel to the `environment.yml` file because I suspect that most users will want to use the conda environment as a kernel for jupyter. I tested the environment (including ipykernel) and all notebooks are running! 

Closes #24 and #21.

This is part of the review process at https://github.com/openjournals/joss-reviews/issues/5510.